### PR TITLE
use platform specific runtime executables

### DIFF
--- a/electron-quick-start-es6/.vscode/launch.json
+++ b/electron-quick-start-es6/.vscode/launch.json
@@ -7,13 +7,20 @@
       "request": "launch",
       "cwd": "${workspaceRoot}",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
-      "program": "${workspaceRoot}/main.js"
+      "windows": {
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+      },
+      "program": "${workspaceRoot}/main.js",
+      "protocol": "legacy"
     },
     {
       "name": "Debug Renderer Process",
       "type": "chrome",
       "request": "launch",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+      "windows": {
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+      },
       "runtimeArgs": [
         "http://localhost:4000",
         "--remote-debugging-port=9222"

--- a/electron-quick-start/.vscode/launch.json
+++ b/electron-quick-start/.vscode/launch.json
@@ -7,17 +7,20 @@
       "request": "launch",
       "cwd": "${workspaceRoot}",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
-      // Use the following for Windows
-      // "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd",
-      "program": "${workspaceRoot}/main.js"
+      "windows": {
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+      },
+      "program": "${workspaceRoot}/main.js",
+      "protocol": "legacy"
     },
     {
       "name": "Debug Renderer Process",
       "type": "chrome",
       "request": "launch",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
-      // Use the following for Windows
-      // "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd",
+      "windows": {
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+      },
       "runtimeArgs": [
         "${workspaceRoot}/main.js",
         "--remote-debugging-port=9222"


### PR DESCRIPTION
- converted the comments about using a different path on Windows into platform-specific settings 
- added a `"protocol": "legacy"` attribute because Electron doesn't (yet) support the '--inspect' flag